### PR TITLE
📝 Add docstrings to `Debugging-Version`

### DIFF
--- a/helper/TabManager.php
+++ b/helper/TabManager.php
@@ -5,6 +5,14 @@ use Laminas\View\Helper\AbstractHelper;
 
 class TabManager extends AbstractHelper
 {
+    /**
+     * Collects resource page blocks for predefined page regions.
+     *
+     * Only regions that contain blocks are included in the result.
+     *
+     * @param mixed $resource The resource (entity or identifier) whose page blocks should be retrieved.
+     * @return array<string, array> Associative array mapping region names to their blocks arrays.
+     */
     public function getResourcePageBlocks($resource) {
         $regions = ['full_width_main', 'left', 'main', 'right'];
         $view = $this->getView();
@@ -20,6 +28,12 @@ class TabManager extends AbstractHelper
         return $regionContent;
     }
 
+    /**
+     * Locate which region contains a `tab_navigation` block for the given resource.
+     *
+     * @param mixed $resource The resource (or resource representation) whose page blocks are inspected.
+     * @return string|false The region name that contains `tab_navigation`, or `false` if none is found.
+     */
     public function getTabNavigationRegion($resource) {
         $resourcePageBlocks = $this->getResourcePageBlocks($resource);
         $tabNavigationRegion = false;
@@ -31,6 +45,14 @@ class TabManager extends AbstractHelper
         return $tabNavigationRegion;
     }
 
+    /**
+     * Render the tab panels for a resource's content region.
+     *
+     * @param mixed  $resource      The resource for which to render panels.
+     * @param string $contentRegion The region containing tab content (default: "main").
+     * @param string $layout        The tab layout to use, e.g. "vertical" or "horizontal" (default: "vertical").
+     * @return string The rendered HTML for the resource's tab panels.
+     */
     public function renderPanels($resource, $contentRegion = 'main', $layout = 'vertical')
     {
         $view = $this->getView();
@@ -42,6 +64,14 @@ class TabManager extends AbstractHelper
         ]);
     }
 
+    /**
+     * Renders the tab navigation markup for a given resource region.
+     *
+     * @param mixed $resource The resource entity or identifier for which to render tab navigation.
+     * @param string $contentRegion The region that contains the tab content (defaults to "main").
+     * @param string $layout The tab layout style, e.g. "vertical" or "horizontal".
+     * @return string The rendered HTML markup for the tab navigation.
+     */
     public function renderTabsOnly($resource, $contentRegion = 'main', $layout = 'vertical') 
     {
         $view = $this->getView();
@@ -53,6 +83,18 @@ class TabManager extends AbstractHelper
         ]);
     }
 
+    /**
+     * Render a region's blocks with the tab navigation for another region injected.
+     *
+     * Injects the tab navigation markup for $contentRegion into the blocks of $currentRegion
+     * and returns the concatenated HTML for that region.
+     *
+     * @param mixed  $resource      The resource whose page blocks are rendered.
+     * @param string $currentRegion The region whose blocks will receive the injected tab navigation.
+     * @param string $contentRegion The region that provides the tab navigation markup (default 'main').
+     * @param string $layout        The tab layout to use (e.g., 'vertical', 'horizontal'; default 'vertical').
+     * @return string The concatenated HTML of the region's blocks with the tab navigation included.
+     */
     public function renderTabsRegion($resource, $currentRegion, $contentRegion = 'main', $layout = 'vertical')
     {
         $view = $this->getView();

--- a/helper/ThemeFunctions.php
+++ b/helper/ThemeFunctions.php
@@ -6,11 +6,22 @@ use Laminas\View\Helper\AbstractHelper;
 
 class ThemeFunctions extends AbstractHelper
 {
+    /**
+     * Allow the helper to be invoked as a function and retrieve the helper instance.
+     *
+     * @return self The helper instance.
+     */
     public function __invoke()
     {
         return $this;
     }
 
+    /**
+     * Return the CSS `font-family` string mapped to a given font key.
+     *
+     * @param string|null $fontKey The font identifier used to look up a font-family. If empty or not present in the internal map, a default system font stack is used.
+     * @return string The CSS `font-family` value for the provided key; falls back to the system font stack when the key is empty or unrecognized.
+     */
     public function getFontFamily($fontKey)
     {
         // Trace for debugging in Apache logs

--- a/src/Config/ModuleConfig.php
+++ b/src/Config/ModuleConfig.php
@@ -128,7 +128,10 @@ class ModuleConfig
     ];
     
     /**
-     * Get theme settings key for a specific theme slug
+     * Builds the storage key for theme settings for the given theme slug.
+     *
+     * @param string $themeSlug The theme slug identifier.
+     * @return string The composed theme settings key.
      */
     public static function getThemeSettingsKey(string $themeSlug): string
     {
@@ -136,7 +139,10 @@ class ModuleConfig
     }
     
     /**
-     * Get defaults storage key for a specific preset
+     * Builds the storage key used to save defaults for a given preset.
+     *
+     * @param string $preset The preset identifier (e.g., 'modern').
+     * @return string The storage key for the preset defaults.
      */
     public static function getDefaultsKey(string $preset): string
     {
@@ -144,7 +150,10 @@ class ModuleConfig
     }
     
     /**
-     * Validate if a preset name is valid
+     * Checks whether a preset name is one of the available presets.
+     *
+     * @param string $preset The preset name to check.
+     * @return bool `true` if the preset exists in AVAILABLE_PRESETS, `false` otherwise.
      */
     public static function isValidPreset(string $preset): bool
     {
@@ -152,7 +161,11 @@ class ModuleConfig
     }
     
     /**
-     * Get error message with formatting
+     * Retrieve a formatted error message template by key.
+     *
+     * @param string $key The error message identifier to look up.
+     * @param mixed ...$args Values to interpolate into the message template via `sprintf`.
+     * @return string The formatted error message; returns `'Unknown error'` if no template is found for the provided key.
      */
     public static function getErrorMessage(string $key, ...$args): string
     {
@@ -161,7 +174,11 @@ class ModuleConfig
     }
     
     /**
-     * Get success message with formatting
+     * Retrieve and format a success message template identified by key.
+     *
+     * @param string $key The message key to look up in SUCCESS_MESSAGES.
+     * @param mixed ...$args Values to interpolate into the message template.
+     * @return string The formatted success message; if the key is missing returns "Operation completed".
      */
     public static function getSuccessMessage(string $key, ...$args): string
     {
@@ -170,15 +187,23 @@ class ModuleConfig
     }
     
     /**
-     * Validate color format
-     */
+         * Checks whether a color string matches the module's configured color pattern.
+         *
+         * @param string $color The color value to validate (must conform to the module's color pattern).
+         * @return bool `true` if the color matches the configured pattern, `false` otherwise.
+         */
     public static function isValidColor(string $color): bool
     {
         return preg_match(self::VALIDATION_RULES['color_pattern'], $color) === 1;
     }
     
     /**
-     * Validate font size format
+     * Determine whether a font size string matches the configured font-size pattern.
+     *
+     * Accepts numeric values with optional units commonly used in CSS (for example "14px", "1.2rem", "100%").
+     *
+     * @param string $fontSize The font size string to validate.
+     * @return bool `true` if `$fontSize` matches the module's font-size pattern, `false` otherwise.
      */
     public static function isValidFontSize(string $fontSize): bool
     {

--- a/src/Service/ErrorHandler.php
+++ b/src/Service/ErrorHandler.php
@@ -14,13 +14,27 @@ class ErrorHandler
 {
     private LoggerInterface $logger;
     
+    /**
+     * Initialize the error handler with an optional PSR-3 logger.
+     *
+     * If no logger is provided, a NullLogger is used.
+     *
+     * @param LoggerInterface|null $logger Optional PSR-3 logger to receive error and audit messages.
+     */
     public function __construct(?LoggerInterface $logger = null)
     {
         $this->logger = $logger ?? new NullLogger();
     }
     
     /**
-     * Handle and log an exception, return user-friendly error message
+     * Handle an exception by logging detailed error information and returning a user-facing message.
+     *
+     * The method logs an error-level entry containing the exception, generated error ID, file, line and stack trace,
+     * then returns a message suitable for display to end users which includes the reference error ID for support.
+     *
+     * @param \Throwable $exception The exception to handle.
+     * @param string $context Optional contextual label (operation, component, or request id) to include in logs.
+     * @return string A user-facing error message that includes a reference error ID. 
      */
     public function handleException(\Throwable $exception, string $context = ''): string
     {
@@ -45,7 +59,10 @@ class ErrorHandler
     }
     
     /**
-     * Validate preset name and return appropriate error if invalid
+     * Validates a preset name and returns an error message when the preset is invalid.
+     *
+     * @param string $preset The preset name to validate.
+     * @return string|null An error message describing the invalid preset if validation fails, `null` otherwise.
      */
     public function validatePreset(string $preset): ?string
     {
@@ -58,7 +75,11 @@ class ErrorHandler
     }
     
     /**
-     * Validate site slug and return appropriate error if invalid
+     * Validate the provided site slug and return a module-specific error message when a required slug is missing.
+     *
+     * @param string|null $siteSlug The site identifier slug to validate; may be null or empty.
+     * @param bool $required When true, an empty or null `$siteSlug` is considered invalid.
+     * @return string|null A module-specific error message if validation fails, or `null` when the slug is accepted.
      */
     public function validateSiteSlug(?string $siteSlug, bool $required = true): ?string
     {
@@ -71,7 +92,14 @@ class ErrorHandler
     }
     
     /**
-     * Validate theme settings data
+     * Validate theme settings and report any format or type violations.
+     *
+     * Validates that each setting value is a string. Keys containing `_color` are
+     * checked for valid color format and keys containing `_font_size` are checked
+     * for valid font-size format.
+     *
+     * @param array $settings Associative array of theme settings (key => value). Keys with `_color` or `_font_size` receive additional format validation.
+     * @return string[] An array of error messages describing each invalid setting; empty if all settings are valid.
      */
     public function validateThemeSettings(array $settings): array
     {
@@ -102,7 +130,11 @@ class ErrorHandler
     }
     
     /**
-     * Handle API errors with context
+     * Create a user-facing API error message for an exception that occurred during an operation.
+     *
+     * @param \Throwable $exception The caught exception.
+     * @param string $operation A short identifier or description of the operation where the error occurred.
+     * @return string The module-specific API error message that includes the exception message.
      */
     public function handleApiError(\Throwable $exception, string $operation): string
     {
@@ -118,7 +150,12 @@ class ErrorHandler
     }
     
     /**
-     * Log successful operations for audit trail
+     * Record a successful operation to the logger for auditing.
+     *
+     * Logs an informational entry that includes the operation name and optional contextual data.
+     *
+     * @param string $operation The name or short description of the successful operation.
+     * @param array $context Optional key-value pairs with additional context to include in the log.
      */
     public function logSuccess(string $operation, array $context = []): void
     {
@@ -126,7 +163,13 @@ class ErrorHandler
     }
     
     /**
-     * Get user-friendly error message based on exception type
+     * Builds a user-facing error message tailored to the given exception and includes the error identifier.
+     *
+     * The returned message is suitable for displaying to end users and always contains the provided error ID.
+     *
+     * @param \Throwable $exception The exception to generate a message from.
+     * @param string $errorId A unique error identifier to append to the message.
+     * @return string The user-facing message including the error ID.
      */
     private function getUserFriendlyMessage(\Throwable $exception, string $errorId): string
     {
@@ -145,7 +188,18 @@ class ErrorHandler
     }
     
     /**
-     * Wrap operation in try-catch with consistent error handling
+     * Execute a callable and return a standardized response array.
+     *
+     * Executes the provided operation. On success returns a response containing the operation result;
+     * on exception logs the error and returns a response containing a user-facing error message.
+     *
+     * @param callable $operation The operation to execute.
+     * @param string $context Optional context label used when logging success or errors.
+     * @return array{
+     *     success: bool,
+     *     data: mixed|null,
+     *     error: string|null
+     * } A standardized response where `success` indicates outcome, `data` holds the result on success or `null` on failure, and `error` holds a user-facing error message or `null`.
      */
     public function wrapOperation(callable $operation, string $context = ''): array
     {
@@ -166,7 +220,15 @@ class ErrorHandler
     }
     
     /**
-     * Create error response array for consistent API responses
+     * Builds a standardized error response array for API consumers.
+     *
+     * @param string $message The error message to include in the response.
+     * @param array $details Additional contextual details to include (optional).
+     * @return array The response array with keys:
+     *               - `success` (bool): false
+     *               - `error` (string): the provided message
+     *               - `details` (array): the provided details
+     *               - `timestamp` (string): current ISO-8601 timestamp
      */
     public function createErrorResponse(string $message, array $details = []): array
     {
@@ -179,7 +241,15 @@ class ErrorHandler
     }
     
     /**
-     * Create success response array for consistent API responses
+     * Builds a standardized success response array for API responses.
+     *
+     * @param mixed  $data    The payload to include in the response.
+     * @param string $message Optional human-readable message.
+     * @return array The response array with keys:
+     *               - 'success' => true
+     *               - 'data' => the provided payload
+     *               - 'message' => the provided message
+     *               - 'timestamp' => ISO 8601 formatted timestamp
      */
     public function createSuccessResponse($data, string $message = ''): array
     {

--- a/src/Service/PresetManager.php
+++ b/src/Service/PresetManager.php
@@ -197,11 +197,11 @@ class PresetManager
     }
 
     /**
-     * Get a specific preset by name
-     * 
-     * @param string $presetName
-     * @return array<string, string>
-     * @throws \InvalidArgumentException if preset doesn't exist
+     * Retrieve preset data for the given preset name.
+     *
+     * @param string $presetName Name of the preset to retrieve.
+     * @return array<string, string> Associative array mapping preset keys to string values.
+     * @throws \InvalidArgumentException If the specified preset does not exist.
      */
     public static function getPreset(string $presetName): array
     {
@@ -213,20 +213,20 @@ class PresetManager
     }
 
     /**
-     * Check if a preset exists
-     * 
-     * @param string $presetName
-     * @return bool
-     */
+         * Determine whether a preset with the given name is registered.
+         *
+         * @param string $presetName The preset identifier to check.
+         * @return bool `true` if a preset with the given name exists, `false` otherwise.
+         */
     public static function hasPreset(string $presetName): bool
     {
         return isset(self::$presets[$presetName]);
     }
 
     /**
-     * Get list of available preset names
-     * 
-     * @return array<string>
+     * List all registered preset names.
+     *
+     * @return array<string> The list of preset names.
      */
     public static function getPresetNames(): array
     {
@@ -234,10 +234,10 @@ class PresetManager
     }
 
     /**
-     * Validate preset data structure
-     * 
-     * @param array<string, string> $presetData
-     * @return bool
+     * Check that every key and value in a preset data array is a string.
+     *
+     * @param array<string, string> $presetData Associative array representing a preset where keys and values must be strings.
+     * @return bool `true` if all keys and values are strings, `false` otherwise.
      */
     public static function validatePresetData(array $presetData): bool
     {


### PR DESCRIPTION
Docstrings generation was requested by @fewarren.

* https://github.com/fewarren/Omeka-S-Library-Theme/pull/3#issuecomment-3362686932

The following files were modified:

* `external/LibraryThemeStyles/Module.php`
* `external/LibraryThemeStyles/src/Controller/AdminController.php`
* `helper/SecurityHelper.php`
* `helper/TabManager.php`
* `helper/ThemeFunctions.php`
* `src/Config/ModuleConfig.php`
* `src/Service/ErrorHandler.php`
* `src/Service/ModuleConfigService.php`
* `src/Service/PresetManager.php`
* `src/Service/ThemeSettingsService.php`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Theme presets in admin: apply presets, save current settings as defaults, load stored defaults, and inspect/diff settings.
  - Enhanced tab rendering: render panels, tabs-only, and inject tab navigation across regions for flexible layouts.
  - Font selection: map theme font keys to sensible CSS font-family stacks.

- Enhancements
  - Improved security and stability: stronger CSRF handling, URL/content sanitization, and basic rate limiting.
  - More informative feedback: clearer success/error messages and user-friendly error outputs with reference IDs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->